### PR TITLE
[정새론] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,9 @@
   <main>
     <section class="hero">
       <div class="hero-content">
-        <div>
+        <div class="hero-info">
           <h1 class="hero-text">
-            일상의 모든 물건을<br />
-            거래해 보세요
+            일상의 모든 물건을 거래해 보세요
           </h1>
           <a href="/items">
             <button class="hero-button">구경하러 가기</button>
@@ -41,8 +40,7 @@
         <div class="feature-content">
           <span>Hot Item</span>
           <h2>
-            인기 상품을<br />
-            확인해 보세요
+            인기 상품을 확인해 보세요
           </h2>
           <p>
             가장 HOT한 중고거래 물품을<br />
@@ -52,19 +50,18 @@
       </div>
     </article>
     <article class="feature-section">
-      <div class="feature">
-        <div class="feature-content-rev">
+      <div class="feature feature-rev">
+        <img src="image/Img_home_02.png" alt="카드 이미지 2번" />
+        <div class="feature-content feature-content-rev">
           <span>Search</span>
           <h2>
-            구매를 원하는<br />
-            상품을 검색하세요
+            구매를 원하는 상품을 검색하세요
           </h2>
           <p>
             구매하고 싶은 물품은 검색해서<br />
             쉽게 찾아보세요
           </p>
         </div>
-        <img src="image/Img_home_02.png" alt="카드 이미지 2번" />
       </div>
     </article>
     <article class="feature-section">
@@ -73,8 +70,7 @@
         <div class="feature-content">
           <span>Register</span>
           <h2>
-            판매를 원하는<br />
-            상품을 등록하세요
+            판매를 원하는 상품을 등록하세요
           </h2>
           <p>
             어떤 물건이든 판매하고 싶은 상품을<br />

--- a/login.css
+++ b/login.css
@@ -92,3 +92,22 @@ footer {
 footer>a {
   color: var(--primary-color);
 }
+
+@media (max-width: 767px) {
+  header {
+    margin-top: 80px;
+  }
+
+  header>a>img {
+    width: 198px;
+  }
+
+  main {
+    width: calc(100% - 32px);
+  }
+
+  form,
+  label {
+    width: 100%;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -7,11 +7,12 @@ header {
   background-color: #fff;
   width: 100%;
   height: 70px;
-  padding: 9px;
-  display: flex;
-  justify-content: center;
   position: fixed;
   top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 header img {
@@ -21,7 +22,6 @@ header img {
 
 .nav-content {
   width: 1120px;
-  margin: 0px 200px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -35,6 +35,7 @@ header img {
   border: 0;
   color: #fff;
   cursor: pointer;
+  margin-left: auto;
 }
 
 .hero {
@@ -51,10 +52,21 @@ header img {
   justify-content: center;
 }
 
+.hero-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hero-info>a {
+  text-decoration-line: none;
+}
+
 .hero-text {
   font-weight: 700;
   font-size: 40px;
   line-height: 140%;
+  word-break: keep-all;
 }
 
 .hero-button {
@@ -68,6 +80,8 @@ header img {
   font-size: 20px;
   line-height: 32px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .hero img {
@@ -79,6 +93,7 @@ header img {
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-bottom: 52px;
 }
 
 .feature {
@@ -91,6 +106,10 @@ header img {
   padding: 0px 12px;
 }
 
+.feature-rev {
+  flex-direction: row-reverse;
+}
+
 .feature-content {
   display: flex;
   flex-direction: column;
@@ -99,21 +118,19 @@ header img {
 }
 
 .feature-content-rev {
-  display: flex;
   text-align: end;
-  flex-direction: column;
-  margin-left: 24px;
-  width: 350px;
 }
 
-.feature span {
+.feature span,
+.feature-rev span {
   color: var(--primary-color);
   font-size: 18px;
   font-weight: 700;
   line-height: 26px;
 }
 
-.feature h2 {
+.feature h2,
+.feature-rev h2 {
   font-weight: 700;
   font-size: 40px;
   line-height: 140%;
@@ -121,11 +138,13 @@ header img {
   margin: 0;
 }
 
-.feature p {
+.feature p,
+.feature-rev p {
   font-weight: 500;
   font-size: 24px;
   line-height: 32px;
 }
+
 
 footer {
   display: flex;
@@ -180,6 +199,11 @@ footer {
   gap: 30px;
 }
 
+.footer-menu>a {
+  text-decoration-line: none;
+  color: #fff;
+}
+
 .footer-social {
   display: flex;
   gap: 12px;
@@ -187,4 +211,143 @@ footer {
 
 .footer-social img {
   cursor: pointer;
+}
+
+@media (max-width: 1200px) {
+  .nav-content {
+    width: 100%;
+    margin: 0px 24px;
+  }
+
+  .hero {
+    height: 771px;
+
+  }
+
+  .hero-content {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .hero-info {
+    margin-bottom: 150px;
+  }
+
+  .feature {
+    height: 708px;
+    flex-direction: column;
+    align-items: start;
+    gap: 16px;
+  }
+
+  .feature-rev {
+    align-items: end;
+  }
+
+
+  .feature h2,
+  .feature-rev h2 {
+    font-weight: 700;
+    font-size: 32px;
+    margin: 0;
+  }
+
+  .feature p,
+  .feature-rev p {
+    font-weight: 500;
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  .footer-content {
+    width: 100%;
+    height: 927px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .footer-info-content {
+    margin: 32px 104px 64px 104px;
+  }
+}
+
+
+@media (max-width: 767px) {
+  .nav-content {
+    width: 100%;
+    margin: 0px 16px;
+  }
+
+  .hero {
+    height: 540px;
+  }
+
+  .hero-content {
+    width: 60%;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .hero-content>img {
+    height: 186px;
+    object-fit: cover;
+  }
+
+  .hero-info {
+    margin-bottom: 10px;
+  }
+
+
+  .hero-button {
+    padding: 16px 32px;
+    display: flex;
+    align-items: center;
+  }
+
+  .feature {
+    height: 708px;
+    flex-direction: column;
+    align-items: start;
+    gap: 16px;
+  }
+
+  .feature>img {
+    width: 100%;
+  }
+
+  .feature-rev {
+    align-items: end;
+  }
+
+
+  .feature h2,
+  .feature-rev h2 {
+    font-weight: 700;
+    font-size: 32px;
+    margin: 0;
+  }
+
+  .feature p,
+  .feature-rev p {
+    font-weight: 500;
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  .footer-content {
+    width: 100%;
+    height: 540px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .footer-content>img {
+    height: 204px;
+  }
+
+  .footer-info-content {
+    margin: 32px 104px 64px 104px;
+  }
 }


### PR DESCRIPTION
## 요구사항

### 기본

#### 공통

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.

#### 랜딩 페이지

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

#### 로그인, 회원가입 페이지 공통

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

#### 심화

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.

## 스크린샷

![image](https://github.com/user-attachments/assets/001feac0-432b-4695-ad78-4a67b79bf269)

![image](https://github.com/user-attachments/assets/a901b42c-5ee9-4b07-974d-d5119b193fa3)

![image](https://github.com/user-attachments/assets/f7182e9a-7f64-48ea-bd8b-6d731a158d65)

## 멘토에게

- CSS 시트 내에 자식 선택자와 하위 선택자가 섞여서 쓰여있는데, 한 단계 아래의 자식을 선택해서 스타일을 적용할 때는 어떤 선택자를 사용하는게 올바른가요?
- 미리보기를 위한 Opengraph를 설정하는 부분이 헷갈립니다. index.html의 <head>부분에 어떻게 추가를 하면 되는지 알고 싶습니다.
