### PR TITLE
[최재이] Sprint4

### DIFF
--- a/login.html
+++ b/login.html
@@ -52,6 +52,6 @@
         </footer>
       </section>
     </main>
-    <script src="login.js"></script>
+    <script src="login1.js"></script>
   </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -109,7 +109,7 @@ if (signupConfirm) {
   signupConfirm.addEventListener("focusout", validateSignupConfirm);
 }
 
-//미션 심화부분
+//심화
 const visibilityBtn = document.querySelector(".btn_visibility");
 const visibilityBtnCheck = document.querySelector(".check");
 

--- a/login.js
+++ b/login.js
@@ -109,7 +109,7 @@ if (signupConfirm) {
   signupConfirm.addEventListener("focusout", validateSignupConfirm);
 }
 
-//심화
+//미션 심화부분
 const visibilityBtn = document.querySelector(".btn_visibility");
 const visibilityBtnCheck = document.querySelector(".check");
 

--- a/login1.js
+++ b/login1.js
@@ -1,0 +1,125 @@
+const email = document.querySelector("#email");
+const password = document.querySelector("#password");
+const nickname = document.querySelector("#nickname");
+const signupConfirm = document.querySelector("#signup-confirm");
+const inputs = document.querySelectorAll("input");
+const submit = document.querySelector(".submit");
+
+function validateEmail() {
+  const emailValue = email.value.trim();
+  const currentError = document.querySelector(".email-error-message");
+
+  if (emailValue === "") {
+    showError(email, "이메일을 입력해주세요.", "email-error-message");
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
+    showError(email, "잘못된 이메일 형식입니다.", "email-error-message");
+  } else {
+    removeError(email, currentError);
+  }
+
+  btnDisable();
+}
+
+function validatePassword() {
+  const passwordValue = password.value.trim();
+  const currentError = document.querySelector(".pw-error-message");
+
+  if (passwordValue === "") {
+    showError(password, "비밀번호를 입력해주세요.", "pw-error-message");
+  } else if (passwordValue.length < 8) {
+    showError(password, "비밀번호를 8자 이상 입력해주세요", "pw-error-message");
+  } else {
+    removeError(password, currentError);
+  }
+
+  btnDisable();
+}
+
+function validateNickname() {
+  const nicknameValue = nickname.value.trim();
+  const currentError = document.querySelector(".nickname-error-message");
+
+  if (nicknameValue === "") {
+    showError(nickname, "닉네임을 입력해주세요.", "nickname-error-message");
+  } else {
+    removeError(nickname, currentError);
+  }
+
+  btnDisable();
+}
+
+function validateSignupConfirm() {
+  const signupConfirmValue = signupConfirm.value.trim();
+  const currentError = document.querySelector(".confirm-error-message");
+
+  if (signupConfirmValue !== password.value) {
+    showError(signupConfirm, "비밀번호가 일치하지 않습니다", "confirm-error-message");
+  } else {
+    removeError(signupConfirm, currentError);
+  }
+
+  btnDisable();
+}
+
+//에러 메세지
+function showError(input, message, errorClass) {
+  input.classList.add("error");
+
+  let errorElement = document.querySelector(`.${errorClass}`);
+  if (!errorElement) {
+    errorElement = document.createElement("span");
+    errorElement.classList.add(errorClass);
+    input.insertAdjacentElement("afterend", errorElement);
+  }
+  errorElement.textContent = message;
+}
+
+//에러 메세지 삭제
+function removeError(input, errorElement) {
+  input.classList.remove("error");
+  if (errorElement) {
+    errorElement.remove();
+  }
+}
+
+// 버튼 활성화/비활성화 함수
+function btnDisable() {
+  const emptyInput = Array.from(inputs).some((input) => input.value.trim() === "");
+  const error =
+    document.querySelector(".email-error-message") ||
+    document.querySelector(".pw-error-message") ||
+    document.querySelector(".nickname-error-message") ||
+    document.querySelector(".confirm-error-message");
+
+  if (emptyInput || error) {
+    submit.disabled = true;
+    submit.classList.add("disabled");
+  } else {
+    submit.disabled = false;
+    submit.classList.remove("disabled");
+  }
+}
+
+email.addEventListener("focusout", validateEmail);
+password.addEventListener("focusout", validatePassword);
+if (nickname) {
+  nickname.addEventListener("focusout", validateNickname);
+}
+if (signupConfirm) {
+  signupConfirm.addEventListener("focusout", validateSignupConfirm);
+}
+
+//심화
+const visibilityBtn = document.querySelector(".btn_visibility");
+const visibilityBtnCheck = document.querySelector(".check");
+
+visibilityBtn.addEventListener("click", function () {
+  const visibilityImg = visibilityBtn.querySelector("img");
+  password.type = password.type === "text" ? "password" : "text";
+  visibilityImg.src = password.type === "text" ? "../images/btn_visibility_on.png" : "../images/btn_visibility_off.png";
+});
+visibilityBtnCheck.addEventListener("click", function () {
+  const visibilityImgCheck = visibilityBtnCheck.querySelector("img");
+  signupConfirm.type = signupConfirm.type === "text" ? "password" : "text";
+  visibilityImgCheck.src = signupConfirm.type === "text" ? "../images/btn_visibility_on.png" : "../images/btn_visibility_off.png";
+});

--- a/signup.html
+++ b/signup.html
@@ -33,7 +33,7 @@
           </div>
           <label for="signup-confirm">비밀번호 확인</label>
           <div class="password-wrap">
-            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="asdffff" />
+            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="" />
             <button type="button" class="btn_visibility check" aria-label="비밀번호 표시" aria-pressed="false">
               <img src="../images/btn_visibility_on.png" width="24px" height="24px" alt="btn_visibility_on_icon" />
             </button>

--- a/signup.html
+++ b/signup.html
@@ -33,7 +33,7 @@
           </div>
           <label for="signup-confirm">비밀번호 확인</label>
           <div class="password-wrap">
-            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="asdffff" />
+            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="" />
             <button type="button" class="btn_visibility check" aria-label="비밀번호 표시" aria-pressed="false">
               <img src="../images/btn_visibility_on.png" width="24px" height="24px" alt="btn_visibility_on_icon" />
             </button>
@@ -56,6 +56,6 @@
         </footer>
       </section>
     </main>
-    <script src="login.js"></script>
+    <script src="login1.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -33,7 +33,7 @@
           </div>
           <label for="signup-confirm">비밀번호 확인</label>
           <div class="password-wrap">
-            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="" />
+            <input type="text" id="signup-confirm" name="signup-confirm" autocomplete="new-password" value="asdffff" />
             <button type="button" class="btn_visibility check" aria-label="비밀번호 표시" aria-pressed="false">
               <img src="../images/btn_visibility_on.png" width="24px" height="24px" alt="btn_visibility_on_icon" />
             </button>


### PR DESCRIPTION
## 요구사항

### 기본

#### 로그인

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '로그인' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 '로그인' 버튼을 누르면 "/items" 로 이동합니다

#### 회원가입

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "닉네임을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 "비밀번호가 일치하지 않습니다.." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '회원가입' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 '회원가입' 버튼을 누르면 로그인 페이지로 이동합니다


### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

-https://cosmic-fairy-5a5953.netlify.app/
-

## 스크린샷

<img width="877" alt="스크린샷 2025-04-24 오후 10 33 21" src="https://github.com/user-attachments/assets/f45accaf-4d3b-43bb-a129-2c8b4c003be7" />
<img width="1096" alt="스크린샷 2025-04-24 오후 10 34 06" src="https://github.com/user-attachments/assets/dc928875-7b25-4c4e-8137-01e8aa7e17a5" />


## 멘토에게

- 
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.