### PR TITLE
[홍성현] sprint3

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -7,4 +7,10 @@ nav {
   position: fixed;
   top: 0;
   width: 100%;
+  height: 70px;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
 }

--- a/assets/css/pages/login-signup.css
+++ b/assets/css/pages/login-signup.css
@@ -1,0 +1,102 @@
+/* login, signup */
+.login-container,
+.signup-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 100px 600px;
+}
+
+.header__login,
+.header__signup {
+  margin-bottom: 40px;
+}
+
+.form__login,
+.form__signup {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.form__label-email,
+.form__label-nickname,
+.form__label-password,
+.form__label-password-confirm {
+  color: var(--color-text-label);
+  margin-bottom: 20px;
+}
+
+.form__input-email,
+.form__input-nickname,
+.form__input-password,
+.form__input-password-confirm {
+  background-color: var(--color-surface-input);
+  padding: 20px;
+  border-radius: 8px;
+  width: 100%;
+}
+
+.form__input-email,
+.form__input-nickname {
+  margin-bottom: 20px;
+}
+
+.form__input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.form__toggle-password,
+.form__toggle-password-confirm {
+  position: absolute;
+  right: 20px;
+  cursor: pointer;
+}
+
+.form__input-button {
+  padding: 20px;
+  background-color: var(--color-primary);
+  color: var(--gray100);
+  border-radius: 40px;
+  cursor: pointer;
+  font-size: var(--font-size-large);
+  margin: 30px 0;
+  width: 100%;
+}
+
+.quick-login {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  background-color: var(--color-primary-surface);
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.footer__link {
+  text-decoration: underline;
+  color: var(--color-primary);
+}
+
+/* login signup mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+  .login-container,
+  .signup-container {
+    margin: 80px 16px 231px;
+    max-width: 400px;
+  }
+}
+
+/* login signup Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .login-container,
+  .signup-container {
+    margin: 0 52px;
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,6 +4,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 12.5rem;
+  background-color: var(--color-nav-background);
 }
 
 .header__login-link {
@@ -31,15 +32,15 @@
   gap: 5%;
 }
 
-.hero__image,
-.closing-banner__image {
-  padding-top: 10rem;
+.closing-banner {
+  margin-top: 83px;
 }
 
 .wrapper {
   display: flex;
   align-items: center;
   max-width: 1200px;
+  padding-top: 200px;
 }
 
 .hero__title,
@@ -84,9 +85,9 @@
 .feature-section__item {
   display: flex;
   align-items: center;
-  margin: 8rem 0;
-  gap: 5%;
+  margin: 40px 0;
   white-space: nowrap;
+  gap: 20px;
 }
 
 .feature-section__item--reverse {
@@ -98,6 +99,7 @@
 .feature-section__content {
   display: flex;
   flex-direction: column;
+  gap: 20px;
 }
 
 /* footer */
@@ -105,14 +107,28 @@
   background-color: var(--color-footer-background);
   display: flex;
   justify-content: space-between;
-  height: 10rem;
-  padding: 2rem 25rem 0;
+  align-items: center;
+  padding: 32px 400px 108px;
+  height: 160px;
+}
+
+.footer__source {
+  font-size: 1rem;
+  color: var(--gray50);
+  white-space: nowrap;
 }
 
 .footer__nav,
 .footer__social {
   display: flex;
-  gap: 5px;
+}
+
+.footer__nav {
+  gap: 30px;
+}
+
+.footer__social {
+  gap: 10px;
 }
 
 .footer__nav-item,
@@ -122,149 +138,161 @@
   white-space: nowrap;
 }
 
-.footer__source {
-  font-size: 1rem;
-  color: var(--gray50);
-}
+/* mobile */
+@media (min-width: 375px) and (max-width: 767px) {
+  br.onlyPC {
+    display: none;
+  }
 
-/* login, signup */
-.login-container,
-.signup-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 100px 600px;
-}
-
-.header__login,
-.header__signup {
-  margin-bottom: 40px;
-}
-
-.form__login,
-.form__signup {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-}
-
-.form__label-email,
-.form__label-nickname,
-.form__label-password,
-.form__label-password-confirm {
-  color: var(--color-text-label);
-  margin-bottom: 20px;
-}
-
-.form__input-email,
-.form__input-nickname,
-.form__input-password,
-.form__input-password-confirm {
-  background-color: var(--color-surface-input);
-  padding: 20px;
-  border-radius: 8px;
-  width: 100%;
-}
-
-.form__input-email,
-.form__input-nickname {
-  margin-bottom: 20px;
-}
-
-.form__input-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-  margin-bottom: 20px;
-}
-
-.form__toggle-password,
-.form__toggle-password-confirm {
-  position: absolute;
-  right: 20px;
-  cursor: pointer;
-}
-
-.form__input-button {
-  padding: 20px;
-  background-color: var(--color-primary);
-  color: var(--gray100);
-  border-radius: 40px;
-  cursor: pointer;
-  font-size: var(--font-size-large);
-  margin: 30px 0;
-  width: 100%;
-}
-
-.quick-login {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  background-color: var(--color-primary-surface);
-  padding: 20px;
-  border-radius: 8px;
-  margin-bottom: 20px;
-}
-
-.footer__link {
-  text-decoration: underline;
-  color: var(--color-primary);
-}
-
-/* @media screen and (max-width: 767px) {
   .header__nav {
-    padding: 1rem;
+    padding: 0 24px;
   }
 
   .wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 0;
   }
 
   .hero__content {
-    padding-top: 4rem;
+    display: flex;
+    flex-direction: column;
+    padding: 48px 67px 132px;
+  }
+
+  .hero__title {
+    font-size: var(--font-size-large);
+    text-align: center;
+  }
+
+  .hero__link {
+    padding: 1rem 4rem;
+    font-size: 1rem;
   }
 
   .hero__image {
-    max-width: 80%;
+    max-width: 100%;
     height: auto;
     vertical-align: bottom;
   }
 
-  .hero__link {
-    margin-top: 1rem;
+  .feature-section__item,
+  .feature-section__item--reverse {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .feature-section__item {
+    align-items: flex-start;
+    width: 100%;
+    padding: 0 10px;
+  }
+
+  .feature-section__item--reverse {
+    align-items: flex-end;
+  }
+
+  .feature-section__headline {
+    font-size: 1.5rem;
+  }
+
+  .feature-section__description {
     font-size: 1rem;
   }
 
-  article {
-    display: flex;
-    flex-direction: column;
+  .closing-banner__headline {
+    text-align: center;
+    margin: 121px 0 131px;
+    font-size: 2rem;
   }
 
-  .search-banner {
-    display: flex;
-    flex-direction: column;
+  .footer {
+    flex-wrap: wrap;
+    padding: 32px;
+    gap: 20px;
   }
 
-  .content-item {
+  .footer__source-wrap {
+    text-align: left;
+    order: 1;
+  }
+}
+
+/* Tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+  br.onlyPC {
+    display: none;
+  }
+
+  .hero {
     display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 24px;
+  }
+
+  .hero__image {
+    max-width: 100%;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    margin-top: 2rem;
+  }
+
+  .hero__content {
+    text-align: center;
+    padding: 48px 0 0;
+    margin: 84px 150px 211px;
+  }
+
+  .hero__title {
+    font-size: 2rem;
+    line-height: 1.4;
+  }
+
+  .hero__link {
+    padding: 1rem 6rem;
+    font-size: 1rem;
+  }
+
+  .header__nav {
+    padding: 0 16px;
+  }
+
+  .feature-section {
+    padding: 0 24px;
+  }
+
+  .feature-section__item {
+    display: flex;
+    flex-direction: column;
     width: 100%;
   }
 
-  h2 {
-    white-space: nowrap;
-    display: inline;
+  .feature-section__content {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .feature-section__content--reverse {
+    align-items: flex-end;
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+  }
+
+  .closing-banner__headline {
+    margin: 201px 225px 211px;
+    text-align: center;
+  }
+
+  .footer {
+    flex-wrap: wrap;
+    padding: 32px 104px 108px;
+    gap: 20px;
   }
 }
-
-@media screen and (max-width: 1024px) {
-  .header__nav {
-    padding: 0 1.5rem;
-  }
-}
-
-@media screen and (min-width: 1920px) {
-} */

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -16,6 +16,7 @@
   --color-surface-input: var(--gray100);
   --color-footer-background: var(--gray900);
   --color-item-link: var(--gray50);
+  --color-nav-background: #ffffff;
 
   --gray900: #111827;
   --gray800: #1f2937;

--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@
       <section class="hero">
         <div class="wrapper">
           <div class="hero__content">
-            <h2 class="hero__title">일상의 모든 물건을<br />거래해 보세요</h2>
+            <h2 class="hero__title">
+              일상의 모든 물건을<br class="onlyPC" />거래해 보세요
+            </h2>
             <a class="hero__link" href="/items" aria-label="상품 목록 구경하기">
               구경하러 가기
             </a>
@@ -67,7 +69,7 @@
           <div class="feature-section__content">
             <h3 class="feature-section__title">Hot item</h3>
             <h2 class="feature-section__headline">
-              인기 상품을<br />확인해 보세요
+              인기 상품을<br class="onlyPC" />확인해 보세요
             </h2>
             <p class="feature-section__description">
               가장 HOT한 중고거래 물품을<br />판다 마켓에서 확인해 보세요
@@ -80,10 +82,12 @@
             alt="검색 기능을 강조하는 돋보기 아이콘. '구매를 원하는 상품을 검색하세요'라는 메시지가 포함되어, 판다 마켓에서 물품 검색의 간편함을 전달합니다."
             loading="lazy"
           />
-          <div class="feature-section__content">
+          <div
+            class="feature-section__content feature-section__content--reverse"
+          >
             <h3 class="feature-section__title">Search</h3>
             <h2 class="feature-section__headline">
-              구매를 원하는<br />상품을 검색하세요
+              구매를 원하는<br class="onlyPC" />상품을 검색하세요
             </h2>
             <p class="feature-section__description">
               구매하고 싶은 물품은 검색해서<br />쉽게 찾아보세요
@@ -99,7 +103,7 @@
           <div class="feature-section__content">
             <h3 class="feature-section__title">Register</h3>
             <h2 class="feature-section__headline">
-              판매를 원하는<br />상품을 등록하세요
+              판매를 원하는<br class="onlyPC" />상품을 등록하세요
             </h2>
             <p class="feature-section__description">
               어떤 물건이든 판매하고 싶은 상품을<br />쉽게 등록하세요
@@ -122,7 +126,7 @@
       </section>
     </main>
     <footer class="footer">
-      <span class="footer__source">© Codeit - 2024</span>
+      <div class="footer__source footer__source-wrap">© Codeit - 2024</div>
       <ul class="footer__nav">
         <li class="footer__nav-item">
           <a href="/privacy" aria-label="정책 페이지로 이동">Privacy Policy</a>

--- a/index.html
+++ b/index.html
@@ -46,8 +46,10 @@
       <section class="hero">
         <div class="wrapper">
           <div class="hero__content">
+            <!-- prettier-ignore -->
             <h2 class="hero__title">
-              일상의 모든 물건을<br class="onlyPC" />거래해 보세요
+              일상의 모든 물건을
+              거래해 보세요
             </h2>
             <a class="hero__link" href="/items" aria-label="상품 목록 구경하기">
               구경하러 가기
@@ -68,8 +70,9 @@
           />
           <div class="feature-section__content">
             <h3 class="feature-section__title">Hot item</h3>
-            <h2 class="feature-section__headline">
-              인기 상품을<br class="onlyPC" />확인해 보세요
+            <!-- prettier-ignore -->
+            <h2 class="feature-section__headline">인기 상품을
+              확인해 보세요
             </h2>
             <p class="feature-section__description">
               가장 HOT한 중고거래 물품을<br />판다 마켓에서 확인해 보세요
@@ -86,8 +89,9 @@
             class="feature-section__content feature-section__content--reverse"
           >
             <h3 class="feature-section__title">Search</h3>
-            <h2 class="feature-section__headline">
-              구매를 원하는<br class="onlyPC" />상품을 검색하세요
+            <!-- prettier-ignore -->
+            <h2 class="feature-section__headline">구매를 원하는
+              상품을 검색하세요
             </h2>
             <p class="feature-section__description">
               구매하고 싶은 물품은 검색해서<br />쉽게 찾아보세요
@@ -102,8 +106,9 @@
           />
           <div class="feature-section__content">
             <h3 class="feature-section__title">Register</h3>
-            <h2 class="feature-section__headline">
-              판매를 원하는<br class="onlyPC" />상품을 등록하세요
+            <!-- prettier-ignore -->
+            <h2 class="feature-section__headline">판매를 원하는
+              상품을 등록하세요
             </h2>
             <p class="feature-section__description">
               어떤 물건이든 판매하고 싶은 상품을<br />쉽게 등록하세요

--- a/login.html
+++ b/login.html
@@ -23,16 +23,22 @@
     <link rel="stylesheet" href="./assets/css/reset.css" />
     <link rel="stylesheet" href="./assets/css/variables.css" />
     <link rel="stylesheet" href="./assets/css/global.css" />
-    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="./assets/css/pages/login-signup.css" />
   </head>
   <body>
     <main class="login-container">
       <header class="header__login">
         <a href="/" aria-label="홈으로 이동">
-          <img
-            src="/assets/images/logos/panda-logo-lg.png"
-            alt="판다 마켓의 상징적인 판다 얼굴 로고"
-          />
+          <picture class="header__login-image">
+            <source
+              srcset="/assets/images/logos/panda-logo.png"
+              media="(max-width: 767px)"
+            />
+            <img
+              src="/assets/images/logos/panda-logo-lg.png"
+              alt="판다 마켓의 상징적인 판다 얼굴 로고"
+            />
+          </picture>
         </a>
       </header>
       <form class="form__login">

--- a/login.html
+++ b/login.html
@@ -23,22 +23,22 @@
     <link rel="stylesheet" href="./assets/css/reset.css" />
     <link rel="stylesheet" href="./assets/css/variables.css" />
     <link rel="stylesheet" href="./assets/css/global.css" />
-    <link rel="stylesheet" href="./assets/css/pages/login-signup.css" />
+    <link rel="stylesheet" href="./assets/css/pages/auth.css" />
   </head>
   <body>
     <main class="login-container">
       <header class="header__login">
         <a href="/" aria-label="홈으로 이동">
-          <picture class="header__login-image">
-            <source
-              srcset="/assets/images/logos/panda-logo.png"
-              media="(max-width: 767px)"
-            />
-            <img
-              src="/assets/images/logos/panda-logo-lg.png"
-              alt="판다 마켓의 상징적인 판다 얼굴 로고"
-            />
-          </picture>
+          <img
+            class="logo-image"
+            srcset="
+            /assets/images/logos/panda-logo.png 200w  
+            /assets/images/logos/panda-logo-lg.png 400w,
+            "
+            sizes="(max-width: 767px) 200px, 400px"
+            src="/assets/images/logos/panda-logo-lg.png"
+            alt="판다 마켓의 상징적인 판다 얼굴 로고"
+          />
         </a>
       </header>
       <form class="form__login">

--- a/signup.html
+++ b/signup.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="./assets/css/reset.css" />
     <link rel="stylesheet" href="./assets/css/variables.css" />
     <link rel="stylesheet" href="./assets/css/global.css" />
-    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="./assets/css/pages/login-signup.css" />
   </head>
   <body>
     <main class="signup-container">

--- a/signup.html
+++ b/signup.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="./assets/css/reset.css" />
     <link rel="stylesheet" href="./assets/css/variables.css" />
     <link rel="stylesheet" href="./assets/css/global.css" />
-    <link rel="stylesheet" href="./assets/css/pages/login-signup.css" />
+    <link rel="stylesheet" href="./assets/css/pages/auth.css" />
   </head>
   <body>
     <main class="signup-container">


### PR DESCRIPTION
## 공통
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다

## 랜딩 페이지
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

## 로그인,회원가입 페이지 공통
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [] 주소와 이미지는 자유롭게 설정하세요.

## 스크린샷
![screencapture-127-0-0-1-5500-index-html-2025-04-29-18_33_29](https://github.com/user-attachments/assets/2a3803f3-6128-4df1-b854-c38f462e36d8)
![screencapture-127-0-0-1-5500-index-html-2025-04-29-18_33_55](https://github.com/user-attachments/assets/5a6ea6b8-b3c9-4965-af30-f363b489225b)
![screencapture-127-0-0-1-5500-login-html-2025-04-29-18_34_38](https://github.com/user-attachments/assets/48c70b0e-6dd1-439b-ac35-bcaac976a105)
![screencapture-127-0-0-1-5500-signup-html-2025-04-29-18_36_10](https://github.com/user-attachments/assets/8e1d2598-f689-4b64-9a09-59f3934af39c)
![screencapture-127-0-0-1-5500-signup-html-2025-04-29-18_36_22](https://github.com/user-attachments/assets/44a09568-1c8a-433a-9f05-5295d88a247d)

## 멘토에게

- font-size를 변수 선언해서 사용하는 방법이랑 rem으로 font-size로 적용하는 부분이랑 겹치는 부분이 있는 것으로 보여, 둘 중 하나만 사용하면 될 것 같은 생각이 드는데, 이에 대한 확실한 정보를 가르쳐주세요!
- 반응형 작업을 할 때 모바일 태플릿 각각 최소사이즈를 맞춰놓고 작업을 해야하는 건지 궁금합니다. 저는 피그마 디자인 시안을 기준으로 작업하긴 했습니다.

*** login.css와 signup.css를 분리하려고 했으나 아직까지는 필요성을 느끼지 못하여 같이 쓰고 있습니다
